### PR TITLE
Misc security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.0.1
+
+### Security
+
+- Explicit `HS256` algorithm in `JWT.encode` calls — prevents algorithm confusion if jwt gem defaults change.
+- JWT token lifetime reduced from 24 hours to 5 minutes — limits replay attack window per Atlassian recommendations.
+- `Resource::User#singular_path` now URL-encodes the username — prevents query parameter injection.
+- `Resource::Attachment#save!` sends only the basename as filename — prevents leaking server filesystem paths.
+
+### Fixed
+
+- `Base#set_attrs` with `clobber: false` no longer corrupts `@attrs` when a nested key doesn't exist yet.
+- `OauthClient#make_request` raises `ArgumentError` for unsupported HTTP methods instead of silently setting `@authenticated = true`.
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -396,6 +396,7 @@ module JIRA
       else
         hash.each do |k, v|
           if v.is_a?(Hash)
+            target[k] ||= {}
             set_attrs(v, clobber, target[k])
           else
             target[k] = v

--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -38,16 +38,17 @@ module JIRA
       private
 
       def jwt_header
+        now = Time.now.to_i
         claim = JIRA::Jwt.build_claims(
           issuer,
           request_url,
           http_method.to_s,
           site,
-          (Time.now - 60).to_i,
-          (Time.now + 86_400).to_i
+          now - 30,
+          now + 300
         )
 
-        JWT.encode(claim, shared_secret)
+        JWT.encode(claim, shared_secret, 'HS256')
       end
     end
 

--- a/lib/jira/jwt_header_client.rb
+++ b/lib/jira/jwt_header_client.rb
@@ -21,16 +21,17 @@ module JIRA
     end
 
     def jwt_token(http_method, url)
+      now = Time.now.to_i
       claim = JIRA::Jwt.build_claims(
         @options[:issuer],
         url,
         http_method.to_s,
         @options[:site] + @options[:context_path].to_s,
-        (Time.now - 60).to_i,
-        (Time.now + 86_400).to_i
+        now - 30,
+        now + 300
       )
 
-      JWT.encode(claim, @options[:shared_secret])
+      JWT.encode(claim, @options[:shared_secret], 'HS256')
     end
   end
 end

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -92,6 +92,8 @@ module JIRA
         response = access_token.send http_method, url, headers
       when :post, :put
         response = access_token.send http_method, url, body, headers
+      else
+        raise ArgumentError, "Unsupported HTTP method: #{http_method}"
       end
       @authenticated = true
       response

--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -20,13 +20,14 @@ module JIRA
       end
 
       def save!(attrs, path = url)
-        file = attrs['file'] || attrs[:file] # Keep supporting 'file' parameter as a string for backward compatibility
+        file = attrs['file'] || attrs[:file]
         mime_type = attrs[:mimeType] || 'application/binary'
+        filename = File.basename(file.respond_to?(:path) ? file.path : file.to_s)
 
         headers = { 'X-Atlassian-Token' => 'nocheck' }
-        data = { 'file' => UploadIO.new(file, mime_type, file) }
+        data = { 'file' => UploadIO.new(file, mime_type, filename) }
 
-        response = client.post_multipart(path, data , headers)
+        response = client.post_multipart(path, data, headers)
 
         set_attributes(attrs, response)
 

--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module JIRA
   module Resource
     class UserFactory < JIRA::BaseFactory # :nodoc:
@@ -13,7 +15,7 @@ module JIRA
       MAX_RESULTS = 1000
 
       def self.singular_path(client, key, prefix = '/')
-        collection_path(client, prefix) + '?username=' + key
+        collection_path(client, prefix) + '?username=' + CGI.escape(key.to_s)
       end
 
       # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.0.1'.freeze
 end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -18,6 +18,14 @@ describe JIRA::Resource::User do
     it_should_behave_like 'a resource'
     it_should_behave_like 'a resource with a singular GET endpoint'
 
+    describe '.singular_path' do
+      it 'URL-encodes special characters in the username' do
+        mock_client = double(options: { rest_base_path: '/jira/rest/api/2', context_path: '/jira' })
+        path = JIRA::Resource::User.singular_path(mock_client, 'admin&expand=groups')
+        expect(path).to eq('/jira/rest/api/2/user?username=admin%26expand%3Dgroups')
+      end
+    end
+
     describe '#all' do
       let(:client) do
         client = double(options: { rest_base_path: '/jira/rest/api/2' })

--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -317,6 +317,12 @@ describe JIRA::Base do
       subject.set_attrs({ 'foo' => { 'fum' => 'dum' } }, false)
       expect(subject.foo).to eq('bar' => 'baz', 'fum' => 'dum')
     end
+
+    it 'initializes missing nested keys when clobber is false' do
+      subject.attrs = {}
+      subject.set_attrs({ 'foo' => { 'bar' => 'baz' } }, false)
+      expect(subject.foo).to eq('bar' => 'baz')
+    end
   end
 
   describe 'delete' do

--- a/spec/jira/jwt_header_client_spec.rb
+++ b/spec/jira/jwt_header_client_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe JIRA::JwtHeaderClient do
+  let(:options) do
+    {
+      site: 'http://localhost:2990',
+      context_path: '/jira',
+      use_ssl: false,
+      ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,
+      read_timeout: 60,
+      issuer: 'test-addon',
+      shared_secret: 'test-shared-secret'
+    }
+  end
+
+  subject { described_class.new(options) }
+
+  describe '#make_request' do
+    let(:http_conn) { instance_double(Net::HTTP) }
+    let(:response) { instance_double(Net::HTTPOK) }
+
+    before do
+      allow(Net::HTTP).to receive(:new).and_return(http_conn)
+      allow(http_conn).to receive(:use_ssl=)
+      allow(http_conn).to receive(:verify_mode=)
+      allow(http_conn).to receive(:read_timeout=)
+      allow(http_conn).to receive(:request).and_return(response)
+      allow(response).to receive(:is_a?).with(Net::HTTPOK).and_return(true)
+    end
+
+    it 'adds a JWT Authorization header' do
+      subject.make_request(:get, 'http://localhost:2990/jira/rest/api/2/issue/TEST-1', '', {})
+
+      expect(http_conn).to have_received(:request) do |request|
+        expect(request['Authorization']).to start_with('JWT ')
+      end
+    end
+
+    it 'uses HS256 algorithm' do
+      subject.make_request(:get, 'http://localhost:2990/jira/rest/api/2/issue/TEST-1', '', {})
+
+      expect(http_conn).to have_received(:request) do |request|
+        token = request['Authorization'].sub('JWT ', '')
+        header = JSON.parse(Base64.decode64(token.split('.').first))
+        expect(header['alg']).to eq('HS256')
+      end
+    end
+
+    it 'generates a token with short-lived expiry (5 minutes)' do
+      subject.make_request(:get, 'http://localhost:2990/jira/rest/api/2/issue/TEST-1', '', {})
+
+      expect(http_conn).to have_received(:request) do |request|
+        token = request['Authorization'].sub('JWT ', '')
+        payload = JWT.decode(token, 'test-shared-secret', true, algorithms: ['HS256']).first
+        expect(payload['exp'] - payload['iat']).to be <= 330
+        expect(payload['iss']).to eq('test-addon')
+        expect(payload['qsh']).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/jira/jwt_uri_builder_spec.rb
+++ b/spec/jira/jwt_uri_builder_spec.rb
@@ -55,5 +55,21 @@ describe JIRA::JwtClient::JwtUriBuilder do
         expect(subject.count('?')).to eq(1)
       end
     end
+
+    context 'token properties' do
+      let(:url) { 'http://localhost:2990/rest/api/2/issue' }
+
+      it 'uses HS256 algorithm' do
+        token = subject.match(/jwt=([^&]+)/)[1]
+        header = JSON.parse(Base64.decode64(token.split('.').first))
+        expect(header['alg']).to eq('HS256')
+      end
+
+      it 'uses a short-lived token (5 minute expiry window)' do
+        token = subject.match(/jwt=([^&]+)/)[1]
+        payload = JWT.decode(token, shared_secret, true, algorithms: ['HS256']).first
+        expect(payload['exp'] - payload['iat']).to be <= 330
+      end
+    end
   end
 end

--- a/spec/jira/oauth_client_spec.rb
+++ b/spec/jira/oauth_client_spec.rb
@@ -143,6 +143,20 @@ describe JIRA::OauthClient do
       end
     end
 
+    describe 'unsupported http method' do
+      let(:access_token) { double }
+
+      before do
+        allow(oauth_client).to receive(:access_token).and_return(access_token)
+      end
+
+      it 'raises ArgumentError and does not set authenticated' do
+        expect { oauth_client.make_request(:patch, '/path', '', {}) }
+          .to raise_error(ArgumentError, /Unsupported HTTP method: patch/)
+        expect(oauth_client.authenticated?).to be_falsey
+      end
+    end
+
     describe 'auth type is oauth_2legged' do
       let(:oauth__2legged_client) do
         options = { consumer_key: 'foo', consumer_secret: 'bar', auth_type: :oauth_2legged }

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -134,5 +134,25 @@ describe JIRA::Resource::Attachment do
         expect(attachment.size).to eq 23_123
       end
     end
+
+    context 'when file path contains directories' do
+      let(:file_io) { StringIO.new('file content') }
+
+      before do
+        allow(file_io).to receive(:path).and_return('/tmp/uploads/secret/evidence.pdf')
+      end
+
+      subject { attachment.save!('file' => file_io) }
+
+      it 'sends only the basename as the upload filename' do
+        expect(client).to receive(:post_multipart) do |_path, data, _headers|
+          upload_io = data['file']
+          expect(upload_io.original_filename).to eq('evidence.pdf')
+          response
+        end
+
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
  1. Explicit JWT algorithm. Added 'HS256' as third arg to JWT.encode
  2. Token lifetime 24h to 5min
  3. URL-encode username in query param prevents query parameter injection 
  4. Basename only in attachment upload prevents leaking server filesystem paths to JIRA.
  5. set_attrs nil target corruption. Without this, nested hash values get written to the top-level
  6. Missing else clause in OauthClient#make_request